### PR TITLE
add tooltip w/ pool assets

### DIFF
--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -494,10 +494,11 @@ export default defineComponent({
 
 <style>
 .horizontalSticky {
-  @apply z-10 bg-white dark:bg-gray-850 group-hover:bg-gray-50 dark:group-hover:bg-gray-800 opacity-95 xs:opacity-90;
+  @apply z-10 bg-white dark:bg-gray-850 group-hover:bg-gray-50 dark:group-hover:bg-gray-800;
   position: sticky;
   left: 0;
   width: 100%;
+  --tw-bg-opacity: 0.9 !important;
 }
 
 .horizontalSticky::after {

--- a/src/components/_global/BalTooltip/BalTooltip.vue
+++ b/src/components/_global/BalTooltip/BalTooltip.vue
@@ -41,7 +41,8 @@ export default defineComponent({
     disabled: { type: Boolean, default: false },
     iconSize: { type: String, defailt: 'md' },
     width: { type: String, default: '52' },
-    textCenter: { type: Boolean, default: false }
+    textCenter: { type: Boolean, default: false },
+    distance: { type: Number, default: 5 }
   },
   setup(props) {
     const activator = ref<HTMLElement>();
@@ -78,7 +79,12 @@ export default defineComponent({
       if (activator.value && content.value) {
         popper.value = createPopper(activator.value, content.value, {
           placement: props.placement,
-          modifiers: [{ name: 'offset', options: { offset: [0, 5] } }]
+          modifiers: [
+            {
+              name: 'offset',
+              options: { offset: [0, props.distance] }
+            }
+          ]
         });
       }
     });

--- a/src/components/_global/BalTooltip/BalTooltip.vue
+++ b/src/components/_global/BalTooltip/BalTooltip.vue
@@ -37,6 +37,7 @@ export default defineComponent({
     onShow: { type: Function },
     onHide: { type: Function },
     noPad: { type: Boolean, default: false },
+    rightPad: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
     iconSize: { type: String, defailt: 'md' },
     width: { type: String, default: '52' },
@@ -49,6 +50,7 @@ export default defineComponent({
 
     const tooltipClasses = computed(() => {
       return {
+        'pr-3': props.rightPad,
         'p-3': !props.noPad,
         [`w-${props.width}`]: true,
         'text-center': props.textCenter

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -42,9 +42,10 @@
           class="rounded-br-xl h-4 w-4 flex bg-yellow-500 absolute top-0 left-0 bg-opacity-80"
         />
         <div v-if="!isLoading" class="px-6 py-4">
-          <BalAssetSet
+          <BalAssetSetWithTooltip
             :addresses="orderedTokenAddressesFor(pool)"
             :width="100"
+            :pool="pool"
           />
         </div>
       </template>
@@ -100,6 +101,7 @@ import useNumbers from '@/composables/useNumbers';
 import useFathom from '@/composables/useFathom';
 
 import LiquidityAPRTooltip from '@/components/tooltips/LiquidityAPRTooltip.vue';
+import BalAssetSetWithTooltip from '@/components/tooltips/BalAssetSetWithTooltip.vue';
 import TokenPills from './TokenPills/TokenPills.vue';
 
 import {
@@ -116,7 +118,8 @@ const POOLS_PER_PAGE = 10;
 
 export default defineComponent({
   components: {
-    LiquidityAPRTooltip
+    LiquidityAPRTooltip,
+    BalAssetSetWithTooltip
     //TokenPills
   },
 

--- a/src/components/tooltips/BalAssetSetWithTooltip.vue
+++ b/src/components/tooltips/BalAssetSetWithTooltip.vue
@@ -33,7 +33,7 @@
       </template>
       <div class="text-sm divide-y dark:divide-gray-900">
         <div class="p-3">
-          <div v-for="(item, idx) in pool.tokens" :key="idx">
+          <div v-for="(item, idx) in tokens" :key="idx">
             <div class="whitespace-nowrap flex items-center mb-1">
               <template v-if="!!item.weight">
                 {{ fNum(item.weight, 'percent') }}</template
@@ -103,6 +103,10 @@ export default defineComponent({
         (radius.value * 2)
     );
 
+    const tokens = computed(() =>
+      props.pool?.tokens.filter(token => token.address !== props.pool?.address)
+    );
+
     /**
      * COMPOSABLES
      */
@@ -123,6 +127,7 @@ export default defineComponent({
     return {
       // computed
       addressesChunks,
+      tokens,
 
       // methods
       leftOffsetFor,

--- a/src/components/tooltips/BalAssetSetWithTooltip.vue
+++ b/src/components/tooltips/BalAssetSetWithTooltip.vue
@@ -3,7 +3,7 @@
     v-for="(addressesChunk, addressChunkIndex) in addressesChunks"
     :key="addressChunkIndex"
   >
-    <BalTooltip width="auto" noPad rightPad placement="right">
+    <BalTooltip width="auto" noPad rightPad :distance="30" placement="right">
       <template v-slot:activator>
         <div
           class="addresses-row"

--- a/src/components/tooltips/BalAssetSetWithTooltip.vue
+++ b/src/components/tooltips/BalAssetSetWithTooltip.vue
@@ -35,7 +35,9 @@
         <div class="p-3">
           <div v-for="(item, idx) in pool.tokens" :key="idx">
             <div class="whitespace-nowrap flex items-center mb-1">
-              {{ fNum(item.weight, 'percent') }}
+              <template v-if="!!item.weight">
+                {{ fNum(item.weight, 'percent') }}</template
+              >
               <span class="ml-1 text-gray-500 text-xs">
                 <BalAsset :address="item.address" :size="16" />
                 {{ item.symbol }}

--- a/src/components/tooltips/BalAssetSetWithTooltip.vue
+++ b/src/components/tooltips/BalAssetSetWithTooltip.vue
@@ -3,7 +3,7 @@
     v-for="(addressesChunk, addressChunkIndex) in addressesChunks"
     :key="addressChunkIndex"
   >
-    <BalTooltip width="auto" noPad rightPad placement="left">
+    <BalTooltip width="auto" noPad rightPad placement="right">
       <template v-slot:activator>
         <div
           class="addresses-row"

--- a/src/components/tooltips/BalAssetSetWithTooltip.vue
+++ b/src/components/tooltips/BalAssetSetWithTooltip.vue
@@ -1,0 +1,148 @@
+<template>
+  <template
+    v-for="(addressesChunk, addressChunkIndex) in addressesChunks"
+    :key="addressChunkIndex"
+  >
+    <BalTooltip width="auto" noPad rightPad placement="left">
+      <template v-slot:activator>
+        <div
+          class="addresses-row"
+          :style="{
+            width: `${width}px`,
+            height: `${size}px`
+          }"
+        >
+          <BalAsset
+            v-for="(address, i) in addressesChunk"
+            :key="i"
+            :address="address"
+            :size="size"
+            :class="[
+              'token-icon',
+              'cursor-pointer',
+              { absolute: !wrap, relative: wrap }
+            ]"
+            :style="{
+              left: `${leftOffsetFor(i)}px`,
+              zIndex: `${20 - i}`,
+              width: `${size}px`,
+              height: `${size}px`
+            }"
+          />
+        </div>
+      </template>
+      <div class="text-sm divide-y dark:divide-gray-900">
+        <div class="p-3">
+          <div v-for="(item, idx) in pool.tokens" :key="idx">
+            <div class="whitespace-nowrap flex items-center mb-1">
+              {{ fNum(item.weight, 'percent') }}
+              <span class="ml-1 text-gray-500 text-xs">
+                <BalAsset :address="item.address" :size="16" />
+                {{ item.symbol }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </BalTooltip>
+  </template>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, PropType } from 'vue';
+import { chunk } from 'lodash';
+import useNumbers from '@/composables/useNumbers';
+import { DecoratedPool } from '@/services/balancer/subgraph/types';
+
+import BalAsset from '../_global/BalAsset/BalAsset.vue';
+
+export default defineComponent({
+  components: {
+    BalAsset
+  },
+  props: {
+    addresses: {
+      type: Array as PropType<string[]>,
+      required: true
+    },
+    width: {
+      type: Number,
+      default: 200
+    },
+    size: {
+      type: Number,
+      default: 26
+    },
+    maxAssetsPerLine: {
+      type: Number,
+      default: 8
+    },
+    wrap: {
+      type: Boolean
+    },
+    pool: {
+      type: Object as PropType<DecoratedPool>
+    }
+  },
+
+  setup(props) {
+    /**
+     * COMPUTED
+     */
+    const addressesChunks = computed(() =>
+      chunk(props.addresses, props.maxAssetsPerLine)
+    );
+
+    const radius = computed(() => props.size / 2);
+
+    const spacer = computed(
+      () =>
+        (props.maxAssetsPerLine / props.addresses.length - 1) *
+        (radius.value * 2)
+    );
+
+    /**
+     * COMPOSABLES
+     */
+    const { fNum } = useNumbers();
+
+    /**
+     * METHODS
+     */
+    function leftOffsetFor(i: number) {
+      if (props.wrap) return 0;
+      return (
+        ((props.width - radius.value * 2 + spacer.value) /
+          (props.maxAssetsPerLine - 1)) *
+        i
+      );
+    }
+
+    return {
+      // computed
+      addressesChunks,
+
+      // methods
+      leftOffsetFor,
+
+      // composables
+      fNum
+    };
+  }
+});
+</script>
+
+<style scoped>
+.addresses-row {
+  @apply relative mb-3 flex;
+}
+.addresses-row:last-child {
+  @apply mb-0;
+}
+.token-icon {
+  margin-left: -2px;
+  @apply rounded-full overflow-hidden shadow-none;
+  @apply bg-white dark:bg-gray-850;
+  @apply border-2 border-white dark:border-gray-850 group-hover:border-gray-50 dark:group-hover:border-gray-800;
+}
+</style>


### PR DESCRIPTION
I wrapped the original BalAssetSet with a BalTooltip and thus created a new component.
Keeping the tooltip on the right should overflow correctly on the top and bottom row.

Because you have to long press on mobile you will also get a popup asking to save the image (default behavior on mobile for an image). I tried to disable this but haven't found a solution for it yet.