### PR TITLE
Feature/add date to chart tooltip

### DIFF
--- a/src/beethovenx/components/pages/portfolio/PortfolioStatWithBarChart.vue
+++ b/src/beethovenx/components/pages/portfolio/PortfolioStatWithBarChart.vue
@@ -116,8 +116,7 @@ export default defineComponent({
         },
         axisTick: {
           show: false
-        },
-        data: props.dates
+        }
       },
       yAxis: {
         type: 'value',
@@ -133,10 +132,16 @@ export default defineComponent({
               ${params
                 .map(
                   param => `
+                <div class="text-sm mb-1 self-center">
+                  ${format(param.value[0] * 1000, 'MMM. d')}
+                </div>
                 <span>
                 ${param.marker} ${
                     param.seriesName
-                  } <span class='font-medium ml-2'>${fNum(param.value, 'usd')}
+                  } <span class='font-medium ml-2'>${fNum(
+                    param.value[1],
+                    'usd'
+                  )}
                   </span>
                 </span>
               `
@@ -150,7 +155,7 @@ export default defineComponent({
         {
           name: props.title,
           type: 'bar',
-          data: props.data,
+          data: props.dates.map((date, index) => [date, props.data[index]]),
           itemStyle: {
             borderRadius: 10
           }

--- a/src/beethovenx/components/pages/portfolio/PortfolioValueLineChart.vue
+++ b/src/beethovenx/components/pages/portfolio/PortfolioValueLineChart.vue
@@ -153,6 +153,9 @@ export default defineComponent({
           formatter: params => {
             return `
             <div class='flex flex-col font-body bg-white dark:bg-gray-800 dark:text-white'>
+              <div class="text-sm mb-1 self-center">
+                ${format(params[0].value[0], 'MMM. d')}
+              </div>
               ${params
                 .map(
                   param => `


### PR DESCRIPTION
Add date in tooltip for value & fee chart on the portfolio page.

![image](https://user-images.githubusercontent.com/20125808/155896652-3017acbc-77df-4337-933a-9db21ce22076.png)

![image](https://user-images.githubusercontent.com/20125808/155896672-dac90362-3335-462b-b800-2a14e06b8f59.png)
