### PR TITLE
does not work against scam tokens

### DIFF
--- a/src/beethovenx/components/pages/invest/TokenSearchInput.vue
+++ b/src/beethovenx/components/pages/invest/TokenSearchInput.vue
@@ -52,11 +52,6 @@ const whiteListedTokens = computed(() =>
   Object.values(tokens.value)
     .filter(token => TOKENS.Popular.Symbols.includes(token.symbol))
     .filter(token => !isTokenSelected(token.address))
-    // filter out duplicates as well (eg yvUSDC, yvDAI are filtered in somewhere)
-    .filter(
-      (token, index, self) =>
-        self.findIndex(t => t.symbol === token.symbol) === index
-    )
 );
 
 function isTokenSelected(token: string) {


### PR DESCRIPTION
I thought yvDAI & yvUSDC were getting filtered out but it turned out to be scam DAI &USDC tokens.
This filter can be removed because it doesn't do anything against those.