### PR TITLE
scroll & center items in modal

### DIFF
--- a/src/components/_global/BalCard/BalCard.vue
+++ b/src/components/_global/BalCard/BalCard.vue
@@ -1,20 +1,22 @@
 <template>
   <div :class="['bal-card', cardClasses]">
-    <div v-if="imgSrc" class="feature" :style="featureStyles" />
-    <div v-if="!!title || $slots.header" :class="['header', headerClasses]">
-      <component :is="titleTag" v-if="!!title" v-text="title" />
-      <div
-        v-if="$slots.header"
-        :class="['header-content', headerContentClasses]"
-      >
-        <slot name="header" />
+    <div :class="['card-container', cardContainerClasses]">
+      <div v-if="imgSrc" class="feature" :style="featureStyles" />
+      <div v-if="!!title || $slots.header" :class="['header', headerClasses]">
+        <component :is="titleTag" v-if="!!title" v-text="title" />
+        <div
+          v-if="$slots.header"
+          :class="['header-content', headerContentClasses]"
+        >
+          <slot name="header" />
+        </div>
       </div>
-    </div>
-    <div :class="['content', contentClasses]">
-      <slot />
-    </div>
-    <div v-if="$slots.footer" :class="['footer', footerClasses]">
-      <slot name="footer" />
+      <div :class="['content', contentClasses]">
+        <slot />
+      </div>
+      <div v-if="$slots.footer" :class="['footer', footerClasses]">
+        <slot name="footer" />
+      </div>
     </div>
   </div>
 </template>
@@ -40,6 +42,7 @@ export default defineComponent({
     rightAlignHeader: { type: Boolean, default: false },
     exposeOverflow: { type: Boolean, default: false },
     overflowYScroll: { type: Boolean, default: false },
+    itemsCenter: { type: Boolean, default: false },
     shadow: {
       type: String,
       default: '',
@@ -52,6 +55,13 @@ export default defineComponent({
   setup(props) {
     const borderClasses = computed(() => {
       return 'border dark:border-gray-900';
+    });
+
+    const cardContainerClasses = computed(() => {
+      return {
+        'overflow-y-scroll': props.overflowYScroll,
+        'items-center': props.itemsCenter
+      };
     });
 
     const cardClasses = computed(() => {
@@ -97,6 +107,7 @@ export default defineComponent({
     }));
 
     return {
+      cardContainerClasses,
       cardClasses,
       contentClasses,
       headerClasses,
@@ -111,6 +122,13 @@ export default defineComponent({
 <style scoped>
 .bal-card {
   @apply flex flex-col;
+}
+
+.card-container {
+  @apply flex flex-col;
+}
+.card-container::-webkit-scrollbar {
+  width: 0;
 }
 
 .header {

--- a/src/components/_global/BalModal/BalModal.vue
+++ b/src/components/_global/BalModal/BalModal.vue
@@ -29,7 +29,7 @@
             :no-content-pad="noContentPad"
             class="modal-card"
             noBorder
-            overflowYScroll
+            itemsCenter
           >
             <template v-if="$slots.header" v-slot:header>
               <slot name="header" />
@@ -90,7 +90,7 @@ export default defineComponent({
 
 <style scoped>
 .bal-modal {
-  @apply top-0 left-0 fixed h-screen w-full z-40;
+  @apply top-0 left-0 fixed h-screen w-full z-40 overflow-auto;
 }
 
 .content-container {
@@ -98,7 +98,7 @@ export default defineComponent({
 }
 
 .content {
-  @apply relative w-full h-3/4 sm:h-auto max-h-screen overflow-hidden;
+  @apply relative w-full h-3/4 sm:h-auto max-h-screen;
   max-width: 450px;
 }
 


### PR DESCRIPTION
Fixes #50 

Scrolling now works on desktop (in small windows) and emulated mobile devices.

![image](https://user-images.githubusercontent.com/20125808/157464208-49ad9089-cd6d-4e43-bdbc-cdacdf7d5d24.png)
