### PR TITLE
do not center items

### DIFF
--- a/src/components/_global/BalModal/BalModal.vue
+++ b/src/components/_global/BalModal/BalModal.vue
@@ -29,7 +29,6 @@
             :no-content-pad="noContentPad"
             class="modal-card"
             noBorder
-            itemsCenter
           >
             <template v-if="$slots.header" v-slot:header>
               <slot name="header" />


### PR DESCRIPTION
Put modal title back on the left.

![image](https://user-images.githubusercontent.com/20125808/157473590-167e6061-9f96-4863-85e5-0b4402053712.png)
