### PR TITLE
added custom percent format

### DIFF
--- a/src/beethovenx/pages/pool/_id.vue
+++ b/src/beethovenx/pages/pool/_id.vue
@@ -307,7 +307,9 @@ export default defineComponent({
 
     const poolFeeLabel = computed(() => {
       if (!pool.value) return '';
-      const feeLabel = `${fNum(pool.value.onchain?.swapFee || '0', 'percent')}`;
+      const feeLabel = `${fNum(pool.value.onchain?.swapFee || '0', null, {
+        format: '0.00[00]%'
+      })}`;
 
       if (feesFixed.value) {
         return t('fixedSwapFeeLabel', [feeLabel]);


### PR DESCRIPTION
On a pool page, the swap fees do not displaying enough decimals when set to .001%.

Added decimal formatting to always display 2 and up to 4 if needed.