### PR TITLE
use value from userPoolData query

### DIFF
--- a/src/beethovenx/components/navs/AppNavClaimBtn.vue
+++ b/src/beethovenx/components/navs/AppNavClaimBtn.vue
@@ -89,6 +89,7 @@ import usePools from '@/composables/pools/usePools';
 import useEthers from '@/composables/useEthers';
 import useBreakpoints from '@/composables/useBreakpoints';
 import { Alert } from '@/composables/useAlerts';
+import useUserPoolsData from '@/beethovenx/composables/useUserPoolsData';
 
 export default defineComponent({
   name: 'AppNavClaimBtn',
@@ -107,6 +108,7 @@ export default defineComponent({
       harvestAllFarms,
       refetchFarmsForUser
     } = usePools();
+    const { userPoolsData } = useUserPoolsData();
     const harvesting = ref(false);
     const { upToLargeBreakpoint } = useBreakpoints();
 
@@ -129,9 +131,7 @@ export default defineComponent({
 
       const pendingRewardTokenValue = sumBy(rewardTokens, token => token.value);
 
-      const averageApr =
-        sumBy(farms, farm => farm.apr * (farm.stake || 0)) /
-        sumBy(farms, farm => farm.stake || 0);
+      const averageApr = userPoolsData.value.averageApr;
 
       return {
         numFarms: farms.filter(farm => farm.stake > 0).length,
@@ -141,7 +141,7 @@ export default defineComponent({
         ),
         pendingRewardValue: fNum(pendingRewardTokenValue, 'usd'),
         apr: fNum(averageApr, 'percent'),
-        dailyApr: fNum(averageApr / 365, 'percent'),
+        dailyApr: fNum(parseFloat(averageApr) / 365, 'percent'),
         rewardTokens
       };
     });

--- a/src/beethovenx/components/navs/AppNavClaimBtn.vue
+++ b/src/beethovenx/components/navs/AppNavClaimBtn.vue
@@ -131,7 +131,7 @@ export default defineComponent({
 
       const pendingRewardTokenValue = sumBy(rewardTokens, token => token.value);
 
-      const averageApr = userPoolsData.value.averageApr;
+      const averageApr = userPoolsData.value.averageFarmApr;
 
       return {
         numFarms: farms.filter(farm => farm.stake > 0).length,


### PR DESCRIPTION
The average apr in the AppNavClaimBtn currently only shows the average beets farm apr. This pr updates it to use the averageFarmApr which includes the third party rewards farm apr.

Before:

![image](https://user-images.githubusercontent.com/20125808/163013745-d0afa761-e0b2-4e16-9f52-e070dcf0ff65.png)


After:

![image](https://user-images.githubusercontent.com/20125808/163013915-c994b495-6573-40aa-953e-9eb2c2ca5327.png)
 