### PR TITLE
Update Pool Verification message on the pool creation page

### DIFF
--- a/src/beethovenx/components/pages/pool-create/PoolCreateActions.vue
+++ b/src/beethovenx/components/pages/pool-create/PoolCreateActions.vue
@@ -76,10 +76,13 @@
       </div>-->
       <div v-if="joined" class="mt-6 mb-2">
         <p class="text-yellow-500">
-          We're still looking for the magic recipe that allows us to verify
-          factory created contracts through the ftmscan API. Until then, please
-          reach out to us on discord and someone from the team will manually
-          verify your contract.
+          Please follow these instructions at
+          <BalLink
+            href="https://docs.beets.fi/developers/pool-verification"
+            external
+            >Pool Verification</BalLink
+          >
+          to verify your pool.
         </p>
       </div>
     </div>

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -317,6 +317,7 @@
   "mustBeValidEmail": "must be a valid email",
   "mustBeValidNum": "must be a valid number",
   "mustBeGreaterThan": "must be greater than {0}",
+  "mustBeLessThanChars": "must be less than {0} characters",
   "mustBeValidAddress": "This is not a valid Ethereum address",
   "myBalance": "My balance",
   "myInvestments": "My V2 Balancer investments",


### PR DESCRIPTION
Changed Pool Verification message on pool creation page from:
![image](https://user-images.githubusercontent.com/99622829/163563918-18286419-b08b-438c-88cc-c9e63a9890a3.png)

to:
![image](https://user-images.githubusercontent.com/99622829/163563503-0edb47c6-f83d-48e8-9f4c-8b074acba88b.png)

Also updated a missing translation string for 'mustBeLessThanChars'