### PR TITLE
Filter My Investment table for pools with small user balances ["dust"]

### DIFF
--- a/src/beethovenx/composables/useUserPoolsData.ts
+++ b/src/beethovenx/composables/useUserPoolsData.ts
@@ -6,7 +6,7 @@ import {
   GqlBeetsUserPoolPoolData,
   UserPoolListItem
 } from '@/beethovenx/services/beethovenx/beethovenx-types';
-import { MINIMUM_DUST_VALUE } from '@/beethovenx/constants/dust';
+import { MINIMUM_DUST_VALUE_USD } from '@/beethovenx/constants/dust';
 
 export default function useUserPoolsData() {
   const userPoolDataQuery = useUserPoolDataQuery();
@@ -48,7 +48,7 @@ export default function useUserPoolsData() {
           hasUnstakedBpt: data?.hasUnstakedBpt
         };
       })
-      .filter(pool => Number(pool.userBalance) > MINIMUM_DUST_VALUE);
+      .filter(pool => Number(pool.userBalance) > MINIMUM_DUST_VALUE_USD);
   });
 
   return {

--- a/src/beethovenx/composables/useUserPoolsData.ts
+++ b/src/beethovenx/composables/useUserPoolsData.ts
@@ -6,6 +6,7 @@ import {
   GqlBeetsUserPoolPoolData,
   UserPoolListItem
 } from '@/beethovenx/services/beethovenx/beethovenx-types';
+import { MINIMUM_DUST_VALUE } from '@/beethovenx/constants/dust';
 
 export default function useUserPoolsData() {
   const userPoolDataQuery = useUserPoolDataQuery();
@@ -46,7 +47,8 @@ export default function useUserPoolsData() {
           userBalance: data?.balanceUSD || '0',
           hasUnstakedBpt: data?.hasUnstakedBpt
         };
-      });
+      })
+      .filter(pool => Number(pool.userBalance) > MINIMUM_DUST_VALUE);
   });
 
   return {

--- a/src/beethovenx/constants/dust.ts
+++ b/src/beethovenx/constants/dust.ts
@@ -1,1 +1,1 @@
-export const MINIMUM_DUST_VALUE = 0.01;
+export const MINIMUM_DUST_VALUE_USD = 0.001;

--- a/src/beethovenx/constants/dust.ts
+++ b/src/beethovenx/constants/dust.ts
@@ -1,0 +1,1 @@
+export const MINIMUM_DUST_VALUE = 0.01;


### PR DESCRIPTION
Added a filter to the usePoolsData get to filter out for small balances. Which is set in a the new constants file \beethovenx\constants\dust.ts

Before showing pools with small user balances:
![image](https://user-images.githubusercontent.com/99622829/163722300-020db46b-5ce5-4bda-abd4-4ef72f08dabf.png)

After with filter:
![image](https://user-images.githubusercontent.com/99622829/163722402-579afc8a-93e4-4dcc-bac6-13cc61d95d3c.png)
