### PR TITLE
updated hero container to span width of page

### DIFF
--- a/src/beethovenx/pages/Home.vue
+++ b/src/beethovenx/pages/Home.vue
@@ -6,7 +6,9 @@ import HomeEducationItems from '@/beethovenx/components/pages/home/HomeEducation
 
 <template>
   <div>
-    <div class="hero-container pt-10 sm:pt-16 lg:pt-8 overflow-hidden">
+    <div
+      class="hero-container -mx-4 lg:-mx-6 pt-10 sm:pt-16 lg:pt-8 overflow-hidden"
+    >
       <div class="mx-auto max-w-7xl">
         <div class="lg:grid lg:grid-cols-2 lg:gap-8">
           <div


### PR DESCRIPTION
Added negative margin so the shadow on the home page has no padding on edge of the screen.

![image](https://user-images.githubusercontent.com/99622829/165296352-b04947d8-4839-4d8a-a743-6cb1d4cbee8d.png)
