### PR TITLE
Price Impact display error on Invest (input timing problem)

### DIFF
--- a/src/composables/usePromiseSequence.ts
+++ b/src/composables/usePromiseSequence.ts
@@ -6,9 +6,9 @@ export default function usePromiseSequence() {
 
   async function processAll(): Promise<void> {
     processing.value = true;
-    for (let i = 0; i < promises.value.length; i++) {
-      await promises.value[i]();
-      promises.value.splice(i, 1);
+    while (promises.value.length > 0) {
+      await promises.value[0]();
+      promises.value.pop();
     }
     processing.value = false;
   }


### PR DESCRIPTION
This is my proposed solution to the price impact input timing problem on the Invest form.

This problem can be reproduced with using any boosted pool. Open the Invest form and type an amount quickly. There will be a price impact error that is not correct.

The problem is with the async function useInvestMath.getBatchSwap. I used a debounce on the input of the form, and on the watch(fullAmount) in useInvestMath. This did solve the calculation problem and the price impact did displayed correctly. But without an amazing amount of blocking code I cannot get the priceImpact computed to not fire. What I found was if i allowed the async getBatchSwap to just return in the correct order everything works correctly.

