### PR TITLE
Updated refetchInterval for queries to reduce ongoing request load.

### DIFF
--- a/src/beethovenx/composables/farms/useFarmUserQuery.ts
+++ b/src/beethovenx/composables/farms/useFarmUserQuery.ts
@@ -97,7 +97,7 @@ export default function useFarmUserQuery(
 
   const queryOptions = reactive({
     enabled,
-    refetchInterval: 3000,
+    refetchInterval: 10000,
     ...options
   });
 

--- a/src/beethovenx/composables/queries/useProtocolDataQuery.ts
+++ b/src/beethovenx/composables/queries/useProtocolDataQuery.ts
@@ -32,7 +32,8 @@ export default function useProtocolDataQuery(
 
   const queryOptions = reactive({
     enabled: true,
-    ...options
+    ...options,
+    refetchInterval: 10000
   });
 
   return useQuery<ProtocolData>(

--- a/src/beethovenx/composables/queries/useUserPoolDataQuery.ts
+++ b/src/beethovenx/composables/queries/useUserPoolDataQuery.ts
@@ -28,7 +28,7 @@ export default function useUserPoolDataQuery(
   const queryOptions = reactive({
     enabled,
     ...options,
-    refetchInterval: 5000
+    refetchInterval: 15000
   });
 
   return useQuery<GqlBeetsUserPoolData>(queryKey, queryFn, queryOptions);

--- a/src/beethovenx/composables/queries/useUserPoolDataQuery.ts
+++ b/src/beethovenx/composables/queries/useUserPoolDataQuery.ts
@@ -28,7 +28,7 @@ export default function useUserPoolDataQuery(
   const queryOptions = reactive({
     enabled,
     ...options,
-    refetchInterval: 15000
+    refetchInterval: 5000
   });
 
   return useQuery<GqlBeetsUserPoolData>(queryKey, queryFn, queryOptions);


### PR DESCRIPTION
useUserPoolDataQuery (query beetsGetUserPoolData). reference in AppNavBelow for the user balance and the claim button AverageApr. And on the pool page for farm stats. This is currently set to 5 second I changed that to 15 seconds.  

useFarmUserQuery (beetsGetBeetsFarms). This is use on the pool page and stake page to show farm data. It is set to 3 second, changed that to 10

useProtocalDataQuery (beetsGetProtocolData). this is use in the AppNavBelow. This has no interval set, so I set it to 10 seconds.
