### PR TITLE
Batch Relayer Approval action removed from Invest when not using Zap

### DIFF
--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActions.vue
@@ -263,6 +263,20 @@ watch(blockNumber, async () => {
   }
 });
 
+watch(stakeBptInFarm, () => {
+  if (
+    actions.value.includes(batchRelayerApproval.action.value) &&
+    !stakeBptInFarm.value
+  ) {
+    actions.value.shift();
+  } else if (
+    (isWeightedPoolWithNestedLinearPools.value || stakeBptInFarm.value) &&
+    !batchRelayerApproval.isUnlocked.value
+  ) {
+    actions.value.unshift(batchRelayerApproval.action.value);
+  }
+});
+
 onBeforeMount(() => {
   if (
     (isWeightedPoolWithNestedLinearPools.value || stakeBptInFarm.value) &&
@@ -276,7 +290,7 @@ onBeforeMount(() => {
 
 <template>
   <div>
-    <BalActionSteps :actions="actions" />
+    <BalActionSteps :actions="actions" :key="stakeBptInFarm" />
     <template v-if="investmentState.confirmed">
       <div
         class="flex items-center justify-between text-gray-400 dark:text-gray-600 mt-4 text-sm"


### PR DESCRIPTION
If a user is not approved for the batch relayer, then if they choose NOT to zap on the invest screen (for weighted pools), the approve needed to be removed.

to test: On the invest preview screen, for a weighted pool. A user without Batch Relayer Approval. Click the Zap toggle and the relayer approval action should be added and removed.