### PR TITLE
On Withdraw modal, updated slider to work with boosted pools

### DIFF
--- a/src/components/_global/BalRangeInput/BalRangeInput.vue
+++ b/src/components/_global/BalRangeInput/BalRangeInput.vue
@@ -15,7 +15,7 @@
     <vue-slider
       v-model="range"
       v-bind="$attrs"
-      @change="onChange"
+      @change="debouncedOnChange"
       @drag-end="onDragEnd"
       :dot-style="dotStyle"
       :rail-style="railSyle"
@@ -30,6 +30,7 @@ import VueSlider from 'vue-slider-component';
 import 'vue-slider-component/theme/antd.css';
 import { theme } from '@/../tailwind.config';
 import useDarkMode from '@/composables/useDarkMode';
+import _debounce from 'lodash/debounce';
 
 export default defineComponent({
   name: 'BalRangeInput',
@@ -51,6 +52,10 @@ export default defineComponent({
     const { darkMode } = useDarkMode();
 
     const colors = theme.extend.colors;
+
+    const debouncedOnChange = _debounce(function(event) {
+      onChange(event);
+    }, 50);
 
     function onChange(value) {
       emit('change', value);
@@ -96,7 +101,8 @@ export default defineComponent({
       onDragEnd,
       dotStyle,
       railSyle,
-      proccessStyle
+      proccessStyle,
+      debouncedOnChange
     };
   }
 });

--- a/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/ProportionalWithdrawalInput.vue
@@ -112,15 +112,14 @@ const seedTokens = computed((): number[] =>
 /**
  * METHODS
  */
-function handleSliderChange(newVal: number): void {
+async function handleSliderChange(newVal: number): Promise<void> {
   const fractionBasisPoints = (newVal / slider.value.max) * 10000;
+
   propBptIn.value = bnum(bptBalance.value)
     .times(fractionBasisPoints)
     .div(10000)
     .toFixed(props.pool.onchain.decimals);
-}
 
-async function handleSliderEnd(): Promise<void> {
   if (shouldFetchBatchSwap.value || shouldFetchExitBatchSwap.value) {
     await props.math.getSwap();
   }
@@ -169,7 +168,6 @@ onBeforeMount(() => {
           tooltip="none"
           :disabled="!hasBpt"
           @update:modelValue="handleSliderChange"
-          @dragEnd="handleSliderEnd"
         />
       </div>
     </div>

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
@@ -26,7 +26,8 @@ const { priceImpact, highPriceImpact, loadingAmountsOut } = toRefs(props.math);
  * COMPUTED
  */
 const priceImpactClasses = computed(() => ({
-  'bg-red-500 text-white divide-red-400 border-none': highPriceImpact.value
+  'dark:bg-gray-800': !highPriceImpact.value,
+  'bg-red-500 dark:bg-red-500 text-white divide-red-400': highPriceImpact.value
 }));
 </script>
 
@@ -70,7 +71,6 @@ const priceImpactClasses = computed(() => ({
   @apply flex;
   @apply rounded-lg;
   @apply divide-x dark:divide-gray-900 border dark:border-gray-900;
-  @apply dark:bg-gray-800;
 }
 
 .data-table-number-col {

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
@@ -32,7 +32,9 @@ const selectedOption = ref(props.initToken);
  * COMPOSABLES
  */
 const { getTokens, getToken, nativeAsset } = useTokens();
-const { isProportional, tokenOut } = useWithdrawalState(toRef(props, 'pool'));
+const { isProportional, tokenOut, maxSlider } = useWithdrawalState(
+  toRef(props, 'pool')
+);
 const { isWethPool, isWeightedPoolWithNestedLinearPools } = usePool(
   toRef(props, 'pool')
 );
@@ -74,9 +76,12 @@ const assetSetWidth = computed(
  * METHODS
  */
 function handleSelected(newToken: string): void {
+  console.log(tokenOut.value, newToken);
   if (newToken === 'all') {
     isProportional.value = true;
     selectedOption.value = 'all';
+    tokenOut.value = 'all';
+    maxSlider();
   } else {
     isProportional.value = false;
     selectedOption.value = newToken;

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -603,10 +603,7 @@ export default function useWithdrawMath(
   );
 
   const shouldFetchBatchSwap = computed(
-    (): boolean =>
-      pool.value &&
-      isStablePhantomPool.value &&
-      bnum(normalizedBPTIn.value).gt(0)
+    (): boolean => pool.value && isStablePhantomPool.value
   );
 
   const shouldFetchExitBatchSwap = computed(
@@ -624,7 +621,10 @@ export default function useWithdrawMath(
     // If batchSwap has any 0 return amounts, we should use batch relayer
     if (batchSwap.value) {
       const returnAmounts = batchSwap.value.returnAmounts;
-      return hasBpt.value && returnAmounts.some(amount => bnum(amount).eq(0));
+      return (
+        bnum(normalizedBPTIn.value).gt(0) &&
+        returnAmounts.some(amount => bnum(amount).eq(0))
+      );
     }
 
     return false;


### PR DESCRIPTION
Slider on the withdraw page did not work with boosted pools. If you slide it now the amount changes. Also was not resetting when the token select was changes. Fixed.

The price impact warning was flashing. Fix. And was never turning red like for the trade and invest pages. Fixed