### PR TITLE
Only show farm actions for supportsMasterChef flag

### DIFF
--- a/src/beethovenx/components/pages/pool/PoolActionsCard.vue
+++ b/src/beethovenx/components/pages/pool/PoolActionsCard.vue
@@ -14,6 +14,7 @@ import { lpTokensFor } from '@/composables/usePool';
 import usePools from '@/composables/pools/usePools';
 import usePoolTransfers from '@/composables/contextual/pool-transfers/usePoolTransfers';
 import BalAlert from '@/components/_global/BalAlert/BalAlert.vue';
+import { configService } from '@/services/config/config.service';
 
 /**
  * TYPES
@@ -37,6 +38,7 @@ const { balanceFor, nativeAsset, wrappedNativeAsset } = useTokens();
 const { fNum, toFiat } = useNumbers();
 const { currency } = useUserSettings();
 const { isWalletReady, toggleWalletSelectModal } = useWeb3();
+const { featureFlags } = configService;
 
 /**
  * COMPUTED
@@ -139,7 +141,7 @@ onBeforeMount(() => {
   </BalCard>
 
   <FarmActionsCard
-    v-if="hasFarm"
+    v-if="hasFarm && featureFlags.supportsMasterChef"
     :has-unstaked-bpt="hasUnstakedBpt"
     :token-address="tokenAddress"
     :farm-id="farmId"

--- a/src/beethovenx/composables/useUserPoolsData.ts
+++ b/src/beethovenx/composables/useUserPoolsData.ts
@@ -7,10 +7,12 @@ import {
   UserPoolListItem
 } from '@/beethovenx/services/beethovenx/beethovenx-types';
 import { MINIMUM_DUST_VALUE_USD } from '@/beethovenx/constants/dust';
+import { configService } from '@/services/config/config.service';
 
 export default function useUserPoolsData() {
   const userPoolDataQuery = useUserPoolDataQuery();
   const { poolList, poolListLoading } = usePoolList();
+  const { featureFlags } = configService;
 
   const userPoolDataLoading = computed(
     () =>
@@ -45,7 +47,8 @@ export default function useUserPoolsData() {
         return {
           ...pool,
           userBalance: data?.balanceUSD || '0',
-          hasUnstakedBpt: data?.hasUnstakedBpt
+          hasUnstakedBpt:
+            data?.hasUnstakedBpt && featureFlags.supportsMasterChef
         };
       })
       .filter(pool => Number(pool.userBalance) > MINIMUM_DUST_VALUE_USD);

--- a/src/beethovenx/pages/pool/_id.vue
+++ b/src/beethovenx/pages/pool/_id.vue
@@ -97,16 +97,18 @@
             <PoolStatCards :pool="pool" :loading="loadingPool" />
           </div>
 
-          <div
-            class="mb-4"
-            v-if="
-              loadingPool || (pool.farm && pool.farm.rewardTokens.length > 0)
-            "
-          >
-            <h4 class="px-4 lg:px-0 mb-4">Farm</h4>
-            <FarmStatCardsLoading v-if="loadingPool || isLoadingFarms" />
-            <FarmStatCards v-else :pool="pool" />
-          </div>
+          <template v-if="networkConfig.featureFlags.supportsMasterChef">
+            <div
+              class="mb-4"
+              v-if="
+                loadingPool || (pool.farm && pool.farm.rewardTokens.length > 0)
+              "
+            >
+              <h4 class="px-4 lg:px-0 mb-4">Farm</h4>
+              <FarmStatCardsLoading v-if="loadingPool || isLoadingFarms" />
+              <FarmStatCards v-else :pool="pool" />
+            </div>
+          </template>
 
           <div class="mb-4">
             <h4 v-text="$t('poolComposition')" class="px-4 lg:px-0 mb-4" />
@@ -402,6 +404,7 @@ export default defineComponent({
       isLoadingFarms,
       hasCustomToken,
       hasDefaultOwner,
+      networkConfig,
       // methods
       fNum,
       onNewTx

--- a/src/components/navs/AppNav/AppNavAccountBtn.vue
+++ b/src/components/navs/AppNav/AppNavAccountBtn.vue
@@ -15,7 +15,7 @@
           v-if="nftImage !== null"
           :src="nftImage"
           width="22"
-          class="rounded-full h-22 w-22"
+          class="rounded-full"
         />
         <Avatar v-else :address="account" :size="avatarSize" />
         <span

--- a/src/components/navs/AppNav/AppNavClaimBtn.vue
+++ b/src/components/navs/AppNav/AppNavClaimBtn.vue
@@ -1,5 +1,5 @@
 <template>
-  <BalPopover no-pad>
+  <BalPopover no-pad v-if="featureFlags.supportsMasterChef">
     <template v-slot:activator>
       <BalBtn
         color="transparent"
@@ -88,6 +88,7 @@ import numeral from 'numeral';
 import usePools from '@/composables/pools/usePools';
 import useEthers from '@/composables/useEthers';
 import useBreakpoints from '@/composables/useBreakpoints';
+import { configService } from '@/services/config/config.service';
 import { Alert } from '@/composables/useAlerts';
 
 export default defineComponent({
@@ -109,6 +110,7 @@ export default defineComponent({
     } = usePools();
     const harvesting = ref(false);
     const { upToLargeBreakpoint } = useBreakpoints();
+    const { featureFlags } = configService;
 
     const data = computed(() => {
       const farms = onlyPoolsWithFarms.value.map(pool => pool.decoratedFarm);
@@ -185,7 +187,8 @@ export default defineComponent({
       harvesting,
       upToLargeBreakpoint,
       isLoadingPools,
-      isLoadingFarms
+      isLoadingFarms,
+      featureFlags
     };
   }
 });

--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -7,12 +7,11 @@
         class="text-base"
         :size="upToLargeBreakpoint ? 'md' : 'sm'"
         :circle="upToLargeBreakpoint"
-        :class="{ btn: upToLargeBreakpoint }"
       >
         <img
           :src="iconSrc(activeNetwork)"
           :alt="activeNetwork.name"
-          class="'h-7 w-7'"
+          width="25"
         />
       </BalBtn>
     </template>

--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -12,7 +12,7 @@
         <img
           :src="iconSrc(activeNetwork)"
           :alt="activeNetwork.name"
-          :class="[bp === 'xs' ? 'h-8 w-8' : 'w-9 h-9', 'pl-2']"
+          class="'h-7 w-7'"
         />
       </BalBtn>
     </template>
@@ -64,7 +64,7 @@ export default defineComponent({
     const configService = new ConfigService();
 
     // COMPOSABLES
-    const { bp, upToLargeBreakpoint } = useBreakpoints();
+    const { upToLargeBreakpoint } = useBreakpoints();
 
     // DATA
     const networks = [
@@ -101,7 +101,6 @@ export default defineComponent({
 
     return {
       // computed
-      bp,
       upToLargeBreakpoint,
       // data
       networks,

--- a/src/components/navs/AppNav/AppNavToggle.vue
+++ b/src/components/navs/AppNav/AppNavToggle.vue
@@ -12,7 +12,11 @@
       :class="['toggle-link px-5', { [activeClasses]: isInvestPage }]"
       @click="trackGoal(Goals.ClickNavInvest)"
     >
-      Invest{{ upToXLargeBreakpoint ? '' : '&nbsp;/&nbsp;Farm' }}
+      Invest{{
+        !upToXLargeBreakpoint && featureFlags.supportsMasterChef
+          ? '&nbsp;/&nbsp;Farm'
+          : ''
+      }}
     </router-link>
     <router-link
       v-if="featureFlags.supportsMasterChef"


### PR DESCRIPTION
Check the config featureFlags.supportsMasterChef for components that display farming information. Disable component if not supported.

Disable messages regarding unstaked BPT supportsMasterChef when false.

Disable AppNavClaim button for supportsMasterChef when false