### PR TITLE
Adjust Tooltips on pool page so they are always visible (staging)

### DIFF
--- a/src/beethovenx/pages/pool/_id.vue
+++ b/src/beethovenx/pages/pool/_id.vue
@@ -33,11 +33,15 @@
             >
               {{ $t('new') }}
             </BalChip>
-            <LiquidityAPRTooltip :pool="pool" class="-ml-1 mt-1" />
+            <LiquidityAPRTooltip
+              placement="bottom"
+              :pool="pool"
+              class="-ml-1 mt-1"
+            />
           </div>
           <div class="flex items-center mt-2">
             <div v-html="poolFeeLabel" class="text-sm" />
-            <BalTooltip>
+            <BalTooltip placement="bottom">
               <template v-slot:activator>
                 <BalLink v-if="hasDefaultOwner">
                   <LudwigIcon class="ml-2" />

--- a/src/components/_global/BalTooltip/BalTooltip.vue
+++ b/src/components/_global/BalTooltip/BalTooltip.vue
@@ -26,7 +26,7 @@ import { computed, defineComponent, onMounted, PropType, ref } from 'vue';
 import { createPopper, Instance as PopperInstance } from '@popperjs/core';
 import BalIcon from '../BalIcon/BalIcon.vue';
 
-type Placement = 'top' | 'left' | 'bottom' | 'right';
+export type Placement = 'top' | 'left' | 'bottom' | 'right';
 
 export default defineComponent({
   name: 'Tooltip',

--- a/src/components/tooltips/LiquidityAPRTooltip.vue
+++ b/src/components/tooltips/LiquidityAPRTooltip.vue
@@ -3,18 +3,22 @@ import { computed } from 'vue';
 import useNumbers from '@/composables/useNumbers';
 import { DecoratedPool } from '@/services/balancer/subgraph/types';
 import { bnum } from '@/lib/utils';
+import { Placement } from '@/components/_global/BalTooltip/BalTooltip.vue';
 
 /**
  * TYPES
  */
 type Props = {
   pool: DecoratedPool;
+  placement: Placement;
 };
 
 /**
  * PROPS
  */
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  placement: 'top'
+});
 
 /**
  * COMPOSABLES
@@ -27,7 +31,7 @@ const hasThirdPartyAPR = computed(() =>
 </script>
 
 <template v-slot:aprCell="pool">
-  <BalTooltip width="auto" noPad>
+  <BalTooltip width="auto" noPad :placement="placement">
     <template v-slot:activator>
       <div class="ml-1">
         <StarsIcon


### PR DESCRIPTION
in some situations the fee tooltip and APR tooltips can be hidden under the AppNav

![image](https://user-images.githubusercontent.com/99622829/171675513-adef3982-828a-474c-a09f-204dc1a1b9fe.png)

for the tooltips on the Pool Page only, set their behavior to bottom, so they will not go under the AppNav