### PR TITLE
remove trailing '/' from etherscan link

### DIFF
--- a/src/beethovenx/config/optimism.json
+++ b/src/beethovenx/config/optimism.json
@@ -9,7 +9,7 @@
   "rpc": "https://mainnet.optimism.io",
   "ws": "wss://ws-mainnet.optimism.io",
   "loggingRpc": "",
-  "explorer": "https://optimistic.etherscan.io/",
+  "explorer": "https://optimistic.etherscan.io",
   "explorerName": "The Optimistic Explorer",
   "subgraph": "https://api.thegraph.com/subgraphs/name/beethovenxfi/beethovenx-optimism",
   "blockSubgraph": "",


### PR DESCRIPTION
remove trailing '/' from etherscan link to eliminate double '//' when tx/address links are generated

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any new dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
