### PR TITLE
On the Invest page, the PoolsTable. The icon column doesn't align left with the header [optimism]

### DIFF
--- a/src/components/tables/LinearPoolsTable/LinearPoolsTable.vue
+++ b/src/components/tables/LinearPoolsTable/LinearPoolsTable.vue
@@ -38,7 +38,7 @@
         </div>
       </template>
       <template v-slot:iconColumnCell="pool">
-        <div v-if="!isLoading" class="px-6 py-4">
+        <div v-if="!isLoading" class="px-6 py-4 text-left">
           <BalAssetSetWithTooltip
             :addresses="orderedTokenAddressesFor(pool)"
             :width="100"

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -41,7 +41,7 @@
           v-if="pool.hasUnstakedBpt"
           class="rounded-br-xl h-4 w-4 flex bg-yellow-500 absolute top-0 left-0 bg-opacity-80"
         />
-        <div v-if="!isLoading" class="px-6 py-4">
+        <div v-if="!isLoading" class="px-6 py-4 text-left">
           <BalAssetSetWithTooltip
             :addresses="orderedTokenAddressesFor(pool)"
             :width="100"


### PR DESCRIPTION
display of current pools table

![image](https://user-images.githubusercontent.com/99622829/172010199-36c6686a-b508-43a7-b59a-6bd8bd90c0c0.png)

updated with align left

![image](https://user-images.githubusercontent.com/99622829/172010206-744c1979-7a8f-4571-ac85-51c9975fea0d.png)
