### PR TITLE
On the Invest page, the PoolsTable. The icon column doesn't align left with the header [fantom]

### DIFF
--- a/src/components/tables/LinearPoolsTable/LinearPoolsTable.vue
+++ b/src/components/tables/LinearPoolsTable/LinearPoolsTable.vue
@@ -38,7 +38,7 @@
         </div>
       </template>
       <template v-slot:iconColumnCell="pool">
-        <div v-if="!isLoading" class="px-6 py-4">
+        <div v-if="!isLoading" class="px-6 py-4 text-left">
           <BalAssetSetWithTooltip
             :addresses="orderedTokenAddressesFor(pool)"
             :width="100"

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -41,7 +41,7 @@
           v-if="pool.hasUnstakedBpt"
           class="rounded-br-xl h-4 w-4 flex bg-yellow-500 absolute top-0 left-0 bg-opacity-80"
         />
-        <div v-if="!isLoading" class="px-6 py-4">
+        <div v-if="!isLoading" class="px-6 py-4 text-left">
           <BalAssetSetWithTooltip
             :addresses="orderedTokenAddressesFor(pool)"
             :width="100"


### PR DESCRIPTION
current icon aligment

![image](https://user-images.githubusercontent.com/99622829/172011431-48fa5010-222d-489f-bd76-fe9a72bc1adb.png)

fixed to left align icons

![image](https://user-images.githubusercontent.com/99622829/172011453-e1638dfd-d75a-45d3-8cff-d5f18ff8e0bc.png)
