### PR TITLE
GaugeStatCard reward display fixes (when balances and rewards are zero)

### DIFF
--- a/src/beethovenx/components/pages/gauge/GaugeStatCards.vue
+++ b/src/beethovenx/components/pages/gauge/GaugeStatCards.vue
@@ -13,12 +13,14 @@
         <div class="text-sm text-gray-500 font-medium mb-2">
           Rewards
         </div>
+        <template v-if="rewardTokens.length === 0"> No rewards</template>
         <div
-          v-for="(rewardToken, i) in pool.gauge.rewardTokens"
+          v-else
+          v-for="(rewardToken, i) in rewardTokens"
           :key="i"
           :class="[
             'text-xl font-medium truncate flex items-center',
-            i < pool.gauge.rewardTokens.length - 1 ? 'mb-1' : ''
+            i < rewardTokens.length - 1 ? 'mb-1' : ''
           ]"
         >
           {{ fNum(rewardToken.rewardsPerDay, 'token_lg') }}
@@ -71,7 +73,7 @@
         label="Harvest"
         block
         color="gradient"
-        :disabled="!pendingRewards"
+        :disabled="!hasPendingRewards"
         :loading="harvesting"
         @click.prevent="harvestRewards"
       />
@@ -107,6 +109,7 @@ export default defineComponent({
     const {
       gaugeUser,
       pendingRewards,
+      hasPendingRewards,
       isPendingRewardsLoading,
       harvest,
       gaugeUserBalance,
@@ -126,7 +129,6 @@ export default defineComponent({
 
       txListener(tx, {
         onTxConfirmed: async () => {
-          //          await refetchPendingRewards(); // TODO, fix useQuery so can refetch
           harvesting.value = false;
         },
         onTxFailed: () => {
@@ -135,15 +137,23 @@ export default defineComponent({
       });
     }
 
+    const rewardTokens = computed(() =>
+      pool.value.gauge?.rewardTokens.filter(
+        rewardToken => Number(rewardToken.rewardsPerDay) > 0
+      )
+    );
+
     return {
       fNum,
       gaugeUser,
       pendingRewards,
+      hasPendingRewards,
       isPendingRewardsLoading,
       harvesting,
       harvestRewards,
       gaugeUserBalanceUsd,
-      gaugeBptBalanceUsd
+      gaugeBptBalanceUsd,
+      rewardTokens
     };
   }
 });


### PR DESCRIPTION
Fixed some display issues on the GaugeStatCard component:

1) If no rewards to claim, disable Harvest button

![image](https://user-images.githubusercontent.com/99622829/174117106-607dfdae-7e08-4381-b8c8-6da1ac2d68d3.png)

2) when reward token is zero per day and My Pending Rewards is zero, do not display

current
![image](https://user-images.githubusercontent.com/99622829/174117611-d4dba3c5-ce87-4609-ac3e-1d33a0c7e618.png)

fixed
![image](https://user-images.githubusercontent.com/99622829/174117673-7ea3aabf-4316-47a4-864a-7c44b2b4e83f.png)




