### PR TITLE
Withdraw LP incorrect for large amounts of USDC without a decimal point

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -396,7 +396,12 @@ export default function useWithdrawMath(
       const indexOfDecimal = amount.indexOf('.');
 
       return parseUnits(
-        amount.slice(0, indexOfDecimal + withdrawalTokens.value[i].decimals),
+        indexOfDecimal === -1
+          ? amount
+          : amount.slice(
+              0,
+              1 + indexOfDecimal + withdrawalTokens.value[i].decimals
+            ),
         withdrawalTokens.value[i].decimals
       ).toString();
     });


### PR DESCRIPTION
Executing a single side withdraw for USDC (anything with a smaller number of decimals) will not withdraw the correct amounts over 100000 (no decimal point, and more than 6 total digits)

Fixed the fullAmountsScaled so the string.split only occurs if there is a decimal point. And when doing the split add the decimal point into the length of the split.

We could possible change the function to just use a parseUnits and do not do the string split to remove extra decimals as the decimals are truncated in the UI?

  const fullAmountsScaled = computed((): string[] => {
    return fullAmounts.value.map((amount, i) =>
      parseUnits(amount, withdrawalTokens.value[i].decimals).toString()
    );