### PR TITLE
Protocol Metrics displayed in V1 are pulled from the V2 backend

### DIFF
--- a/src/beethovenx/composables/queries/useProtocolMetricsQuery.ts
+++ b/src/beethovenx/composables/queries/useProtocolMetricsQuery.ts
@@ -1,0 +1,43 @@
+import { reactive } from 'vue';
+import { useQuery } from 'vue-query';
+import { QueryObserverOptions } from 'react-query/core';
+import QUERY_KEYS from '@/beethovenx/constants/queryKeys';
+import { beethovenxV2Service } from '@/beethovenx/services/beethovenx/beethovenxV2.service';
+
+interface ProtocolMetrics {
+  totalLiquidity: number;
+  totalSwapVolume: number;
+  totalSwapFee: number;
+  poolCount: number;
+  swapFee24h: number;
+  swapVolume24h: number;
+}
+
+export default function useProtocolMetricsQuery(
+  options: QueryObserverOptions<ProtocolMetrics> = {}
+) {
+  const queryFn = async () => {
+    const protocolMetrics = await beethovenxV2Service.getProtocolMetrics();
+
+    return {
+      totalLiquidity: parseFloat(protocolMetrics.totalLiquidity),
+      totalSwapVolume: parseFloat(protocolMetrics.totalSwapVolume),
+      totalSwapFee: parseFloat(protocolMetrics.totalSwapFee),
+      poolCount: parseInt(protocolMetrics.poolCount),
+      swapFee24h: parseFloat(protocolMetrics.swapFee24h),
+      swapVolume24h: parseFloat(protocolMetrics.swapVolume24h)
+    };
+  };
+
+  const queryOptions = reactive({
+    enabled: true,
+    ...options,
+    refetchInterval: 10000
+  });
+
+  return useQuery<ProtocolMetrics>(
+    QUERY_KEYS.ProtocolMetrics.All,
+    queryFn,
+    queryOptions
+  );
+}

--- a/src/beethovenx/constants/queryKeys.ts
+++ b/src/beethovenx/constants/queryKeys.ts
@@ -130,6 +130,9 @@ const QUERY_KEYS = {
   ProtocolData: {
     All: ['protocolData', 'all']
   },
+  ProtocolMetrics: {
+    All: ['protocolMetrics', 'all']
+  },
   Dexes: {
     GetAmountsOut: ['Dexes', 'GetAmountsOut', 'all']
   },

--- a/src/beethovenx/services/beethovenx/beethovenx-types.ts
+++ b/src/beethovenx/services/beethovenx/beethovenx-types.ts
@@ -45,7 +45,7 @@ export interface UserPortfolio {
   history: UserPortfolioData[];
 }
 
-interface Scalars {
+export interface Scalars {
   ID: string;
   String: string;
   Boolean: boolean;

--- a/src/beethovenx/services/beethovenx/beethovenxV2-types.ts
+++ b/src/beethovenx/services/beethovenx/beethovenxV2-types.ts
@@ -1,0 +1,11 @@
+import { Scalars } from './beethovenx-types';
+
+export interface GqlProtocolMetrics {
+  __typename: 'GqlProtocolMetrics';
+  poolCount: Scalars['BigInt'];
+  swapFee24h: Scalars['BigDecimal'];
+  swapVolume24h: Scalars['BigDecimal'];
+  totalLiquidity: Scalars['BigDecimal'];
+  totalSwapFee: Scalars['BigDecimal'];
+  totalSwapVolume: Scalars['BigDecimal'];
+}

--- a/src/beethovenx/services/beethovenx/beethovenxV2.service.ts
+++ b/src/beethovenx/services/beethovenx/beethovenxV2.service.ts
@@ -1,0 +1,65 @@
+import { configService as _configService } from '@/services/config/config.service';
+import axios from 'axios';
+import { GqlProtocolMetrics } from './beethovenxV2-types';
+
+export type Price = { [fiat: string]: number };
+export type TokenPrices = { [address: string]: Price };
+export type HistoricalPrices = { [timestamp: string]: number[] };
+
+export default class BeethovenxV2Service {
+  private readonly url: string;
+  private tokenPrices: TokenPrices = {};
+
+  constructor(private readonly configService = _configService) {
+    this.url =
+      this.configService.network.key === '10'
+        ? 'https://backend-optimism-v2.beets-ftm-node.com/'
+        : 'https://backend-v2.beets-ftm-node.com/';
+  }
+
+  private async get<T>(query: string, address?: string): Promise<T> {
+    try {
+      const {
+        data: { data }
+      } = await axios.post(
+        this.url,
+        { query },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            AccountAddress: address,
+            'apollographql-client-name': 'web',
+            'apollographql-client-version': '1.0'
+          }
+        }
+      );
+      return data;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+
+  public async getProtocolMetrics(): Promise<GqlProtocolMetrics> {
+    const query = `
+      query GetProtocolData {
+        protocolData: protocolMetrics {
+          totalLiquidity
+          totalSwapVolume
+          totalSwapFee
+          poolCount
+          swapFee24h
+          swapVolume24h
+        }
+      }
+    `;
+
+    const { protocolData } = await this.get<{
+      protocolData: GqlProtocolMetrics;
+    }>(query);
+
+    return protocolData;
+  }
+}
+
+export const beethovenxV2Service = new BeethovenxV2Service();

--- a/src/beethovenx/services/beethovenx/beethovenxV2.service.ts
+++ b/src/beethovenx/services/beethovenx/beethovenxV2.service.ts
@@ -11,10 +11,7 @@ export default class BeethovenxV2Service {
   private tokenPrices: TokenPrices = {};
 
   constructor(private readonly configService = _configService) {
-    this.url =
-      this.configService.network.key === '10'
-        ? 'https://backend-optimism-v2.beets-ftm-node.com/'
-        : 'https://backend-v2.beets-ftm-node.com/';
+    this.url = 'https://backend-v2.beets-ftm-node.com/';
   }
 
   private async get<T>(query: string, address?: string): Promise<T> {

--- a/src/components/navs/AppNav/AppNavBelow.vue
+++ b/src/components/navs/AppNav/AppNavBelow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import useProtocolDataQuery from '@/beethovenx/composables/queries/useProtocolDataQuery';
+import useProtocolMetricsQuery from '@/beethovenx/composables/queries/useProtocolMetricsQuery';
 import { computed } from 'vue';
 import useNumbers from '@/composables/useNumbers';
 import BalLoadingBlock from '@/components/_global/BalLoadingBlock/BalLoadingBlock.vue';
@@ -7,16 +7,20 @@ import useUserPoolsData from '@/beethovenx/composables/useUserPoolsData';
 import useWeb3 from '@/services/web3/useWeb3';
 
 const { fNum } = useNumbers();
-const protocolDataQuery = useProtocolDataQuery();
+const protocolMetricsQuery = useProtocolMetricsQuery();
 const { userPoolsData, userPoolDataLoading } = useUserPoolsData();
 const { isWalletReady } = useWeb3();
-const procotolDataLoading = computed(() => protocolDataQuery.isLoading.value);
-const tvl = computed(() => protocolDataQuery.data?.value?.totalLiquidity || 0);
+const procotolDataLoading = computed(
+  () => protocolMetricsQuery.isLoading.value
+);
+const tvl = computed(
+  () => protocolMetricsQuery.data?.value?.totalLiquidity || 0
+);
 const swapFee24h = computed(
-  () => protocolDataQuery.data?.value?.swapFee24h || 0
+  () => protocolMetricsQuery.data?.value?.swapFee24h || 0
 );
 const swapVolume24h = computed(
-  () => protocolDataQuery.data?.value?.swapVolume24h || 0
+  () => protocolMetricsQuery.data?.value?.swapVolume24h || 0
 );
 </script>
 


### PR DESCRIPTION
TVL and 24 hour volume and fees are being queried from the V2 backend service.
backend URL is hardcoded into the V2 service.

![image](https://user-images.githubusercontent.com/99622829/183708804-d382711a-5bbe-41f1-8cf9-28a3d0d90916.png)
